### PR TITLE
Allow realname configurability

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,4 @@ default[:irccat][:cat_host] = "127.0.0.1"
 default[:irccat][:script_path] = "/etc/irccat/handler.sh"
 default[:irccat][:channels] = [ { :name => "#test", :key => "" } ]
 default[:irccat][:user] = "irccat"
+default[:irccat][:realname] = "irccat"

--- a/templates/default/irccat.xml.erb
+++ b/templates/default/irccat.xml.erb
@@ -18,6 +18,7 @@
                 <nick><%= node[:irccat][:nick] %></nick>
                 <!-- The number of milliseconds between each outgoing message in the bot's queue -->
                 <messagedelay>250</messagedelay>
+                <version><%= node[:irccat][:realname] %></version>
         </bot>
 
         <!-- Address/port to listen on for data to cat to IRC -->


### PR DESCRIPTION
Defaults to `irccat`, override with: `node.set[:irccat][:realname]`